### PR TITLE
Fix/connection var

### DIFF
--- a/include/client_stub.h
+++ b/include/client_stub.h
@@ -24,40 +24,40 @@ struct rtable_t;
  * em que address_port é uma string no formato <hostname>:<port>.
  * Retorna a estrutura rtable preenchida, ou NULL em caso de erro.
  */
-struct rtable_t *rtable_connect(char *address_port);
+struct rtable_t *rtable_connect(char *address_port,int* connected);
 
 /* Termina a associação entre o cliente e o servidor, fechando a 
  * ligação com o servidor e libertando toda a memória local.
  * Retorna 0 se tudo correr bem, ou -1 em caso de erro.
  */
-int rtable_disconnect(struct rtable_t *rtable);
+int rtable_disconnect(struct rtable_t *rtable,int* connected);
 
 /* Função para adicionar um elemento na tabela.
  * Se a key já existe, vai substituir essa entrada pelos novos dados.
  * Retorna 0 (OK, em adição/substituição), ou -1 (erro).
  */
-int rtable_put(struct rtable_t *rtable, struct entry_t *entry);
+int rtable_put(struct rtable_t *rtable, struct entry_t *entry,int* connected);
 
 /* Retorna o elemento da tabela com chave key, ou NULL caso não exista
  * ou se ocorrer algum erro.
  */
-struct data_t *rtable_get(struct rtable_t *rtable, char *key);
+struct data_t *rtable_get(struct rtable_t *rtable, char *key,int* connected);
 
 /* Função para remover um elemento da tabela. Vai libertar 
  * toda a memoria alocada na respetiva operação rtable_put().
  * Retorna 0 (OK), ou -1 (chave não encontrada ou erro).
  */
-int rtable_del(struct rtable_t *rtable, char *key);
+int rtable_del(struct rtable_t *rtable, char *key,int* connected);
 
 /* Retorna o número de elementos contidos na tabela ou -1 em caso de erro.
  */
-int rtable_size(struct rtable_t *rtable);
+int rtable_size(struct rtable_t *rtable,int* connected);
 
 /* Retorna um array de char* com a cópia de todas as keys da tabela,
  * colocando um último elemento do array a NULL.
  * Retorna NULL em caso de erro.
  */
-char **rtable_get_keys(struct rtable_t *rtable);
+char **rtable_get_keys(struct rtable_t *rtable,int* connected);
 
 /* Liberta a memória alocada por rtable_get_keys().
  */
@@ -66,7 +66,7 @@ void rtable_free_keys(char **keys);
 /* Retorna um array de entry_t* com todo o conteúdo da tabela, colocando
  * um último elemento do array a NULL. Retorna NULL em caso de erro.
  */
-struct entry_t **rtable_get_table(struct rtable_t *rtable);
+struct entry_t **rtable_get_table(struct rtable_t *rtable,int* connected);
 
 /* Liberta a memória alocada por rtable_get_table().
  */
@@ -74,6 +74,6 @@ void rtable_free_entries(struct entry_t **entries);
 
 /* Obtém as estatísticas do servidor. 
  */
-struct statistics_t *rtable_stats(struct rtable_t *rtable);
+struct statistics_t *rtable_stats(struct rtable_t *rtable,int* connected);
 
 #endif

--- a/include/network_client.h
+++ b/include/network_client.h
@@ -19,7 +19,7 @@
  *   na estrutura rtable;
  * - Retornar 0 (OK) ou -1 (erro).
  */
-int network_connect(struct rtable_t *rtable);
+int network_connect(struct rtable_t *rtable, int* connected);
 
 /* Esta função deve:
  * - Obter o descritor da ligação (socket) da estrutura rtable_t;
@@ -30,11 +30,11 @@ int network_connect(struct rtable_t *rtable);
  * - Tratar de forma apropriada erros de comunicação;
  * - Retornar a mensagem de-serializada ou NULL em caso de erro.
  */
-MessageT *network_send_receive(struct rtable_t *rtable, MessageT *msg);
+MessageT *network_send_receive(struct rtable_t *rtable, MessageT *msg,int* connected);
 
 /* Fecha a ligação estabelecida por network_connect().
  * Retorna 0 (OK) ou -1 (erro).
  */
-int network_close(struct rtable_t *rtable);
+int network_close(struct rtable_t *rtable, int* connected);
 
 #endif

--- a/include/table_client-private.h
+++ b/include/table_client-private.h
@@ -12,8 +12,8 @@
 #include "watcher_callbacks.h"
 #include <unistd.h>
 
-extern volatile sig_atomic_t connected_to_head;
-extern volatile sig_atomic_t connected_to_tail;
+// extern volatile sig_atomic_t connected_to_head; //i think they might not need to be global since we're passing them manually around.
+// extern volatile sig_atomic_t connected_to_tail;
 extern volatile sig_atomic_t client_connected_to_zk; 
 extern char* head_path;
 extern char* tail_path;

--- a/source/network_client.c
+++ b/source/network_client.c
@@ -52,7 +52,7 @@ int network_connect(struct rtable_t *rtable, int* connected) {
     }
 
     rtable->sockfd = sockfd;
-    connected = 1;
+    *connected = 1;
     return 0;
 }
 

--- a/source/table_client.c
+++ b/source/table_client.c
@@ -16,8 +16,8 @@
 #include <zookeeper/zookeeper.h>
 #include "watcher_callbacks.h"
 
-volatile sig_atomic_t connected_to_head = 0; 
-volatile sig_atomic_t connected_to_tail = 0; 
+sig_atomic_t connected_to_head = 0; 
+sig_atomic_t connected_to_tail = 0; 
 volatile sig_atomic_t client_connected_to_zk = 0; 
 static zhandle_t *zh;
 

--- a/source/table_server.c
+++ b/source/table_server.c
@@ -118,13 +118,13 @@ returns -1 if error, 0 if fine.
 */
 int dup_table_from_server(char* last_node_addr){
     // connect as client
-    struct rtable_t* rtable = rtable_connect(last_node_addr);
+    struct rtable_t* rtable = rtable_connect(last_node_addr,&connected_to_server);
     if (!rtable) return -1;
-    struct entry_t** entries = rtable_get_table(rtable);
+    struct entry_t** entries = rtable_get_table(rtable,&connected_to_server);
     if (!entries) return -1;
-    int tab_size = rtable_size(rtable);
+    int tab_size = rtable_size(rtable,&connected_to_server);
     if (tab_size==-1) return -1;
-    rtable_disconnect(rtable);
+    rtable_disconnect(rtable,&connected_to_server);
     int ret = 0;
     for(int i = 0; i < tab_size;i++){
         ret = table_put(resources.table,entries[i]->key,entries[i]->value);

--- a/source/table_server.c
+++ b/source/table_server.c
@@ -22,7 +22,7 @@ typedef struct String_vector zoo_string;
 server_resources resources = {}; 
 volatile sig_atomic_t terminated = 0;
 volatile sig_atomic_t connected_to_zk = 0;
-volatile sig_atomic_t connected_to_server = 0; // FIXME: check if this right? used for copying. might be used later?
+sig_atomic_t connected_to_server = 0; // FIXME: check if this right? used for copying. might be used later?
 char* root_path = "/chain";
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
Changed the way "server connection" is checked. it's passed in as a variable, and no longer has to be a global var. This is so there doesn't need to be a difference between connected to head/tail (as client) vs connected to server (as server serving as client)